### PR TITLE
hide a11y warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,9 @@
     "a11y-distracting-elements": "ignore",
     "a11y-structure": "ignore",
     "a11y-mouse-events-have-key-events": "ignore",
-    "a11y-missing-content": "ignore"
+    "a11y-missing-content": "ignore",
+    "a11y-no-noninteractive-tabindex":"ignore",
+
   },
   "files.exclude": {
     "**/src-tauri": true

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,7 +6,13 @@ const config = {
 	kit: {
 		adapter: adapter({ out: 'build' }),
 	},
-	preprocess: vitePreprocess()
+	preprocess: vitePreprocess(),
+	onwarn: (warning, handler) => {
+		if (warning.code.startsWith('a11y-')) {
+			return;
+		}
+		handler(warning);
+	},
 };
 
 export default config;


### PR DESCRIPTION
- Added a11y warning handler to svelte.config.js as answered in ->  [How can we disable svelte warnings? (a11y, etc) #650](https://github.com/sveltejs/language-tools/issues/650#issuecomment-1328105986)
- Added `"a11y-no-noninteractive-tabindex"` warning to ignore list in .vscode/settings.json